### PR TITLE
fix: bump webdriver version that has directConnect feature fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "web2driver",
       "version": "3.0.2",
       "license": "Apache-2.0",
       "dependencies": {
@@ -12,7 +13,7 @@
         "@wdio/protocols": "^7.7.4",
         "lodash": "^4.17.11",
         "process": "^0.11.10",
-        "webdriver": "^7.12.5"
+        "webdriver": "^7.16.14"
       },
       "devDependencies": {
         "chai": "^4.1.2",
@@ -1888,9 +1889,9 @@
       }
     },
     "node_modules/@sindresorhus/is": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.2.0.tgz",
-      "integrity": "sha512-VkE3KLBmJwcCaVARtQpfuKcKv8gcBmUubrfHGF84dXuuW6jgsRYxPtzcIhPyK9WAPpRt2/xY6zkD9MnRaJzSyw==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.4.0.tgz",
+      "integrity": "sha512-QppPM/8l3Mawvh4rn9CNEYIU9bxpXUCRMaX9yUpvBk1nMKusLKpfXGDEKExKaPhLzcn3lzil7pR6rnJ11HgeRQ==",
       "engines": {
         "node": ">=10"
       },
@@ -1982,9 +1983,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "16.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
-      "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g=="
+      "version": "17.0.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.13.tgz",
+      "integrity": "sha512-Y86MAxASe25hNzlDbsviXl8jQHb0RDvKt4c40ZJQ1Don0AAL0STLZSs4N+6gLEO55pedy7r2cLwS+ZDxPm/2Bw=="
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
@@ -2007,12 +2008,12 @@
       "dev": true
     },
     "node_modules/@wdio/config": {
-      "version": "7.12.5",
-      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-7.12.5.tgz",
-      "integrity": "sha512-eJvVTdPIIudOW8MhG6gg7tZRfrwV2hajx7ntNg0JBvNkUzssgOD/XCyrJBNBC7C1+hvykV5mTcdnZFPyIPVC2A==",
+      "version": "7.16.14",
+      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-7.16.14.tgz",
+      "integrity": "sha512-CdB8F4XFbuH9W3JaLYQoJMPRzM+GQirg9Ay1dW4xNcmJk7m3TJbk3/L78oz8ey1TpCLjQTG8aNqI4SZlFO4JRg==",
       "dependencies": {
-        "@wdio/logger": "7.7.0",
-        "@wdio/types": "7.12.5",
+        "@wdio/logger": "7.16.0",
+        "@wdio/types": "7.16.14",
         "deepmerge": "^4.0.0",
         "glob": "^7.1.2"
       },
@@ -2021,9 +2022,9 @@
       }
     },
     "node_modules/@wdio/logger": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-7.7.0.tgz",
-      "integrity": "sha512-XX/OkC8NlvsBdhKsb9j7ZbuQtF/Vuo0xf38PXdqYtVezOrYbDuba0hPG++g/IGNuAF34ZbSi+49cvz4u5w92kQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-7.16.0.tgz",
+      "integrity": "sha512-/6lOGb2Iow5eSsy7RJOl1kCwsP4eMlG+/QKro5zUJsuyNJSQXf2ejhpkzyKWLgQbHu83WX6cM1014AZuLkzoQg==",
       "dependencies": {
         "chalk": "^4.0.0",
         "loglevel": "^1.6.0",
@@ -2035,37 +2036,32 @@
       }
     },
     "node_modules/@wdio/protocols": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-7.12.1.tgz",
-      "integrity": "sha512-RMZltyM3PqDuaENqAiMwjqQG6y/np+agjv6oTOYSej9FzfkwJeCK2w1KhtYMmISlpodYqioXm8TLxpk0wE+QcA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-7.16.7.tgz",
+      "integrity": "sha512-Wv40pNQcLiPzQ3o98Mv4A8T1EBQ6k4khglz/e2r16CTm+F3DDYh8eLMAsU5cgnmuwwDKX1EyOiFwieykBn5MCg==",
       "engines": {
         "node": ">=12.0.0"
       }
     },
     "node_modules/@wdio/types": {
-      "version": "7.12.5",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.12.5.tgz",
-      "integrity": "sha512-xgxT3JTTLkCmrZ0IqQz0+/DEog98a3viCWwi2MoFZavfENd2QCPzDc7hk2nSoKQQqtJECwBBwWvR9GMzIo2N3Q==",
+      "version": "7.16.14",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.16.14.tgz",
+      "integrity": "sha512-AyNI9iBSos9xWBmiFAF3sBs6AJXO/55VppU/eeF4HRdbZMtMarnvMuahM+jlUrA3vJSmDW+ufelG0MT//6vrnw==",
       "dependencies": {
-        "@types/node": "^15.12.5",
+        "@types/node": "^17.0.4",
         "got": "^11.8.1"
       },
       "engines": {
         "node": ">=12.0.0"
       }
     },
-    "node_modules/@wdio/types/node_modules/@types/node": {
-      "version": "15.14.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.9.tgz",
-      "integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A=="
-    },
     "node_modules/@wdio/utils": {
-      "version": "7.12.5",
-      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-7.12.5.tgz",
-      "integrity": "sha512-j2bkGHGYvFHYy4/JLRvBpNQH2hgneKquuRQlVj0D44E2Ldp9P2DZT2wZ01lC4qtHItjic40YFZry9Dc/PFKwew==",
+      "version": "7.16.14",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-7.16.14.tgz",
+      "integrity": "sha512-wwin8nVpIlhmXJkq6GJw9aDDzgLOJKgXTcEua0T2sdXjoW78u5Ly/GZrFXTjMGhacFvoZfitTrjyfyy4CxMVvw==",
       "dependencies": {
-        "@wdio/logger": "7.7.0",
-        "@wdio/types": "7.12.5",
+        "@wdio/logger": "7.16.0",
+        "@wdio/types": "7.16.14",
         "p-iteration": "^1.1.8"
       },
       "engines": {
@@ -4945,16 +4941,16 @@
       }
     },
     "node_modules/got": {
-      "version": "11.8.2",
-      "resolved": "https://registry.npmjs.org/got/-/got-11.8.2.tgz",
-      "integrity": "sha512-D0QywKgIe30ODs+fm8wMZiAcZjypcCodPNuMz5H9Mny7RJ+IjJ10BdmGW7OM7fHXP+O7r6ZwapQ/YQmMSvB0UQ==",
+      "version": "11.8.3",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.3.tgz",
+      "integrity": "sha512-7gtQ5KiPh1RtGS9/Jbv1ofDpBFuq42gyfEib+ejaRBJuj/3tQFeR5+gw57e4ipaU8c/rCjvX6fkQz2lyDlGAOg==",
       "dependencies": {
         "@sindresorhus/is": "^4.0.0",
         "@szmarczak/http-timer": "^4.0.5",
         "@types/cacheable-request": "^6.0.1",
         "@types/responselike": "^1.0.0",
         "cacheable-lookup": "^5.0.3",
-        "cacheable-request": "^7.0.1",
+        "cacheable-request": "^7.0.2",
         "decompress-response": "^6.0.0",
         "http2-wrapper": "^1.0.0-beta.5.2",
         "lowercase-keys": "^2.0.0",
@@ -6191,9 +6187,9 @@
       }
     },
     "node_modules/keyv": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.3.tgz",
-      "integrity": "sha512-zdGa2TOpSZPq5mU6iowDARnMBZgtCqJ11dJROFi6tg6kTn4nuUdU09lFyLFSaHrWqpIJ+EBq4E8/Dc0Vx5vLdA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.5.tgz",
+      "integrity": "sha512-531pkGLqV3BMg0eDqqJFI0R1mkK1Nm5xIP2mM6keP5P8WfFtCkg2IOwplTUmlGoTgIg9yQYZ/kdihhz89XH3vA==",
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -10543,16 +10539,16 @@
       "dev": true
     },
     "node_modules/webdriver": {
-      "version": "7.12.5",
-      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-7.12.5.tgz",
-      "integrity": "sha512-+IjLy47jf+ijo1xdu5MtrPqaNtGtTM4sq8bjjwrCQ6cAvVcofKoC27jU5XxNESJ5Dlc0bi7cVIrvswTIJ9aLXw==",
+      "version": "7.16.14",
+      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-7.16.14.tgz",
+      "integrity": "sha512-wfD3Okv+XJVMzrFVSTkhU381pJn2HlbKyURC7uY4E2QLaalhJLrrqekofBOUsr7WMf9nqoQwiVHQygnyt0afFw==",
       "dependencies": {
-        "@types/node": "^15.12.5",
-        "@wdio/config": "7.12.5",
-        "@wdio/logger": "7.7.0",
-        "@wdio/protocols": "7.12.1",
-        "@wdio/types": "7.12.5",
-        "@wdio/utils": "7.12.5",
+        "@types/node": "^17.0.4",
+        "@wdio/config": "7.16.14",
+        "@wdio/logger": "7.16.0",
+        "@wdio/protocols": "7.16.7",
+        "@wdio/types": "7.16.14",
+        "@wdio/utils": "7.16.14",
         "got": "^11.0.2",
         "ky": "^0.28.5",
         "lodash.merge": "^4.6.1"
@@ -10560,11 +10556,6 @@
       "engines": {
         "node": ">=12.0.0"
       }
-    },
-    "node_modules/webdriver/node_modules/@types/node": {
-      "version": "15.14.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.9.tgz",
-      "integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A=="
     },
     "node_modules/webidl-conversions": {
       "version": "4.0.2",
@@ -12214,9 +12205,9 @@
       }
     },
     "@sindresorhus/is": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.2.0.tgz",
-      "integrity": "sha512-VkE3KLBmJwcCaVARtQpfuKcKv8gcBmUubrfHGF84dXuuW6jgsRYxPtzcIhPyK9WAPpRt2/xY6zkD9MnRaJzSyw=="
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.4.0.tgz",
+      "integrity": "sha512-QppPM/8l3Mawvh4rn9CNEYIU9bxpXUCRMaX9yUpvBk1nMKusLKpfXGDEKExKaPhLzcn3lzil7pR6rnJ11HgeRQ=="
     },
     "@swc/helpers": {
       "version": "0.2.13",
@@ -12296,9 +12287,9 @@
       }
     },
     "@types/node": {
-      "version": "16.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
-      "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g=="
+      "version": "17.0.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.13.tgz",
+      "integrity": "sha512-Y86MAxASe25hNzlDbsviXl8jQHb0RDvKt4c40ZJQ1Don0AAL0STLZSs4N+6gLEO55pedy7r2cLwS+ZDxPm/2Bw=="
     },
     "@types/parse-json": {
       "version": "4.0.0",
@@ -12321,20 +12312,20 @@
       "dev": true
     },
     "@wdio/config": {
-      "version": "7.12.5",
-      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-7.12.5.tgz",
-      "integrity": "sha512-eJvVTdPIIudOW8MhG6gg7tZRfrwV2hajx7ntNg0JBvNkUzssgOD/XCyrJBNBC7C1+hvykV5mTcdnZFPyIPVC2A==",
+      "version": "7.16.14",
+      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-7.16.14.tgz",
+      "integrity": "sha512-CdB8F4XFbuH9W3JaLYQoJMPRzM+GQirg9Ay1dW4xNcmJk7m3TJbk3/L78oz8ey1TpCLjQTG8aNqI4SZlFO4JRg==",
       "requires": {
-        "@wdio/logger": "7.7.0",
-        "@wdio/types": "7.12.5",
+        "@wdio/logger": "7.16.0",
+        "@wdio/types": "7.16.14",
         "deepmerge": "^4.0.0",
         "glob": "^7.1.2"
       }
     },
     "@wdio/logger": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-7.7.0.tgz",
-      "integrity": "sha512-XX/OkC8NlvsBdhKsb9j7ZbuQtF/Vuo0xf38PXdqYtVezOrYbDuba0hPG++g/IGNuAF34ZbSi+49cvz4u5w92kQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-7.16.0.tgz",
+      "integrity": "sha512-/6lOGb2Iow5eSsy7RJOl1kCwsP4eMlG+/QKro5zUJsuyNJSQXf2ejhpkzyKWLgQbHu83WX6cM1014AZuLkzoQg==",
       "requires": {
         "chalk": "^4.0.0",
         "loglevel": "^1.6.0",
@@ -12343,33 +12334,26 @@
       }
     },
     "@wdio/protocols": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-7.12.1.tgz",
-      "integrity": "sha512-RMZltyM3PqDuaENqAiMwjqQG6y/np+agjv6oTOYSej9FzfkwJeCK2w1KhtYMmISlpodYqioXm8TLxpk0wE+QcA=="
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-7.16.7.tgz",
+      "integrity": "sha512-Wv40pNQcLiPzQ3o98Mv4A8T1EBQ6k4khglz/e2r16CTm+F3DDYh8eLMAsU5cgnmuwwDKX1EyOiFwieykBn5MCg=="
     },
     "@wdio/types": {
-      "version": "7.12.5",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.12.5.tgz",
-      "integrity": "sha512-xgxT3JTTLkCmrZ0IqQz0+/DEog98a3viCWwi2MoFZavfENd2QCPzDc7hk2nSoKQQqtJECwBBwWvR9GMzIo2N3Q==",
+      "version": "7.16.14",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.16.14.tgz",
+      "integrity": "sha512-AyNI9iBSos9xWBmiFAF3sBs6AJXO/55VppU/eeF4HRdbZMtMarnvMuahM+jlUrA3vJSmDW+ufelG0MT//6vrnw==",
       "requires": {
-        "@types/node": "^15.12.5",
+        "@types/node": "^17.0.4",
         "got": "^11.8.1"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "15.14.9",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.9.tgz",
-          "integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A=="
-        }
       }
     },
     "@wdio/utils": {
-      "version": "7.12.5",
-      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-7.12.5.tgz",
-      "integrity": "sha512-j2bkGHGYvFHYy4/JLRvBpNQH2hgneKquuRQlVj0D44E2Ldp9P2DZT2wZ01lC4qtHItjic40YFZry9Dc/PFKwew==",
+      "version": "7.16.14",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-7.16.14.tgz",
+      "integrity": "sha512-wwin8nVpIlhmXJkq6GJw9aDDzgLOJKgXTcEua0T2sdXjoW78u5Ly/GZrFXTjMGhacFvoZfitTrjyfyy4CxMVvw==",
       "requires": {
-        "@wdio/logger": "7.7.0",
-        "@wdio/types": "7.12.5",
+        "@wdio/logger": "7.16.0",
+        "@wdio/types": "7.16.14",
         "p-iteration": "^1.1.8"
       }
     },
@@ -14630,16 +14614,16 @@
       }
     },
     "got": {
-      "version": "11.8.2",
-      "resolved": "https://registry.npmjs.org/got/-/got-11.8.2.tgz",
-      "integrity": "sha512-D0QywKgIe30ODs+fm8wMZiAcZjypcCodPNuMz5H9Mny7RJ+IjJ10BdmGW7OM7fHXP+O7r6ZwapQ/YQmMSvB0UQ==",
+      "version": "11.8.3",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.3.tgz",
+      "integrity": "sha512-7gtQ5KiPh1RtGS9/Jbv1ofDpBFuq42gyfEib+ejaRBJuj/3tQFeR5+gw57e4ipaU8c/rCjvX6fkQz2lyDlGAOg==",
       "requires": {
         "@sindresorhus/is": "^4.0.0",
         "@szmarczak/http-timer": "^4.0.5",
         "@types/cacheable-request": "^6.0.1",
         "@types/responselike": "^1.0.0",
         "cacheable-lookup": "^5.0.3",
-        "cacheable-request": "^7.0.1",
+        "cacheable-request": "^7.0.2",
         "decompress-response": "^6.0.0",
         "http2-wrapper": "^1.0.0-beta.5.2",
         "lowercase-keys": "^2.0.0",
@@ -15563,9 +15547,9 @@
       }
     },
     "keyv": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.3.tgz",
-      "integrity": "sha512-zdGa2TOpSZPq5mU6iowDARnMBZgtCqJ11dJROFi6tg6kTn4nuUdU09lFyLFSaHrWqpIJ+EBq4E8/Dc0Vx5vLdA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.5.tgz",
+      "integrity": "sha512-531pkGLqV3BMg0eDqqJFI0R1mkK1Nm5xIP2mM6keP5P8WfFtCkg2IOwplTUmlGoTgIg9yQYZ/kdihhz89XH3vA==",
       "requires": {
         "json-buffer": "3.0.1"
       }
@@ -18910,26 +18894,19 @@
       "dev": true
     },
     "webdriver": {
-      "version": "7.12.5",
-      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-7.12.5.tgz",
-      "integrity": "sha512-+IjLy47jf+ijo1xdu5MtrPqaNtGtTM4sq8bjjwrCQ6cAvVcofKoC27jU5XxNESJ5Dlc0bi7cVIrvswTIJ9aLXw==",
+      "version": "7.16.14",
+      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-7.16.14.tgz",
+      "integrity": "sha512-wfD3Okv+XJVMzrFVSTkhU381pJn2HlbKyURC7uY4E2QLaalhJLrrqekofBOUsr7WMf9nqoQwiVHQygnyt0afFw==",
       "requires": {
-        "@types/node": "^15.12.5",
-        "@wdio/config": "7.12.5",
-        "@wdio/logger": "7.7.0",
-        "@wdio/protocols": "7.12.1",
-        "@wdio/types": "7.12.5",
-        "@wdio/utils": "7.12.5",
+        "@types/node": "^17.0.4",
+        "@wdio/config": "7.16.14",
+        "@wdio/logger": "7.16.0",
+        "@wdio/protocols": "7.16.7",
+        "@wdio/types": "7.16.14",
+        "@wdio/utils": "7.16.14",
         "got": "^11.0.2",
         "ky": "^0.28.5",
         "lodash.merge": "^4.6.1"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "15.14.9",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.9.tgz",
-          "integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A=="
-        }
       }
     },
     "webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,6 @@
     "@wdio/protocols": "^7.7.4",
     "lodash": "^4.17.11",
     "process": "^0.11.10",
-    "webdriver": "^7.12.5"
+    "webdriver": "^7.16.14"
   }
 }


### PR DESCRIPTION
https://github.com/webdriverio/webdriverio/releases/tag/v7.16.14 has directConnect feature fix.
Then, I'd like to apply the latest version to appium-inspector

@jlipps 